### PR TITLE
Increased merchant data export time for US devs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This endpoint will allow you to get bulk payment and order data from merchants t
 
 - Availability of the service:
 
-    - US (https://api.clover.com) UTC: MON-FRI 10:00-13:00, SAT 10:00-13:00, SUN 10:00-13:00
+    - US (https://api.clover.com) UTC: MON-FRI 10:00-15:00, SAT 10:00-15:00, SUN 10:00-15:00
     - EU (https://api.eu.clover.com) UTC: MON-FRI 01:00-05:00, SAT 02:00-05:00, SUN 02:00-06:00
     - Sandbox (https://apisandbox.dev.clover.com) is not limited to certain times.
 


### PR DESCRIPTION
As per https://jira.dev.clover.com/browse/DP-2619, the merchant data export time for US devs has been increased from 10:00-13:00 UTC to 10:00-15:00 UTC.